### PR TITLE
make LLM API Endpoint and model configurable

### DIFF
--- a/Classes/Api/OpenAiClient.php
+++ b/Classes/Api/OpenAiClient.php
@@ -18,8 +18,12 @@ readonly class OpenAiClient
         $apiKey = $this->extensionConfiguration->get('ai_filemetadata', 'apiKey');
         $organizationId = $this->extensionConfiguration->get('ai_filemetadata', 'organizationId');
         $projectId = $this->extensionConfiguration->get('ai_filemetadata', 'projectId');
-
+        $APIBaseUri = $this->extensionConfiguration->get('ai_filemetadata', 'apiBaseUri');
+        if ($APIBaseUri === '') {
+            $APIBaseUri = 'https://api.openai.com/v1/';
+        }
         $this->openAiClient = OpenAI::factory()
+            ->withBaseUri($APIBaseUri)
             ->withApiKey($apiKey)
             ->withOrganization($organizationId)
             ->withHttpHeader('OpenAI-Project', $projectId)
@@ -42,8 +46,13 @@ GPT;
 
         $this->logger->info('Prompt: ' . $prompt);
 
+        $modell = $this->extensionConfiguration->get('ai_filemetadata', 'model');
+        if ($modell === '') {
+            $modell = 'gpt-4o-mini';
+        }
+
         $response = $this->openAiClient->chat()->create([
-            'model' => 'gpt-4o-mini',
+            'model' => $modell,
             'messages' => [
                 [
                     'role' => 'user',

--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ your privacy and data protection policies if the usage of the services for the i
 
 ## Configuration
 
-Acquire the [OpenAI API key from Open-AI](https://platform.openai.com/docs/quickstart) and place the key in extension configuration.
+Acquire the [OpenAI API key from Open-AI](https://platform.openai.com/docs/quickstart) and place the key in extension
+configuration. Modell for openAI gpt-4o-mini but can be changed to any other modell which supports imageprocessing.
+
+Alternatively setup AI hosting in the mittwald cloud and add the AI Base URL (API) to the configuration and select
+an active modell
 
 ### Language Mapping
 

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -19,6 +19,12 @@
 			<trans-unit id="extconf.generate_alt_text_on_file_upload" resname="extconf.project_id">
 				<source>Generate alt-texts on file upload</source>
 			</trans-unit>
+            <trans-unit id="extconf.api_base_uri" resname="extconf.project_id">
+                <source>Alternative API Endpoint. If not set openAI is used</source>
+            </trans-unit>
+            <trans-unit id="extconf.api_base_uri" resname="extconf.model">
+                <source>Selected model, default gpt-4o-mini</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -7,6 +7,12 @@ organizationId =
 # cat=OpenAI; type=string; label=LLL:EXT:ai_filemetadata/Resources/Private/Language/locallang_be.xlf:extconf.project_id
 projectId =
 
+# cat=OpenAI; type=string; label=LLL:EXT:ai_filemetadata/Resources/Private/Language/locallang_be.xlf:extconf.api_base_uri
+apiBaseUri = https://api.openai.com/v1
+
+# cat=OpenAI; type=string; label=LLL:EXT:ai_filemetadata/Resources/Private/Language/locallang_be.xlf:extconf.model
+model = gpt-4o-mini
+
 # cat=OpenAI; type=options[Disable=0,Shrink to fit 256x256px=256,Shrink to fit 512x512px=512,Shrink to fit 1024x1024px=1024]; label=LLL:EXT:ai_filemetadata/Resources/Private/Language/locallang_be.xlf:extconf.image_resizing
 imageResizing = 512
 


### PR DESCRIPTION
make LLM API endpoint and model configurable. Teste with mitwald cloud LLM hosting: Endpoint https://llm.aihosting.mittwald.de/v1 and model 'Mistral-Small-3.2-24B-Instruct'