### PR TITLE
Dont't try to make descriptions from non existent images.

### DIFF
--- a/Classes/Services/FalAdapter.php
+++ b/Classes/Services/FalAdapter.php
@@ -177,6 +177,9 @@ class FalAdapter
                 }
             }
 
+            if (!$file->exists()) {
+                continue;
+            }
             $altText = $this->openAiClient->buildAltText(
                 $this->resizeImage($file)->getContents(),
                 $falLanguages[$sysLanguageUid]


### PR DESCRIPTION
If a file is in the database, but not in the folder, an error occurs is in 

`cms-core/Classes/Resource/ResourceStorage.php`

to prevent this the existenz of the file is checked before that.