### PR TITLE
[FEATURE] Added temperature parameter to fine-tune alt-text creativity

### DIFF
--- a/Classes/Api/OpenAiClient.php
+++ b/Classes/Api/OpenAiClient.php
@@ -32,6 +32,11 @@ readonly class OpenAiClient
 
     public function buildAltText(string $image, ?string $locale = null): string
     {
+        $temperature = (float)$this->extensionConfiguration->get('ai_filemetadata', 'temperature');
+        if ($temperature < 0.1 || $temperature > 1 ) {
+            $temperature = 0.6;
+        }
+
         $prompt = <<<'GPT'
 Create an alternative text for this image to be used on websites for visually impaired people who cannot see the image.
 Focus on the image's main content and ignore all elements in the image not relevant to understand its message.
@@ -53,6 +58,7 @@ GPT;
 
         $response = $this->openAiClient->chat()->create([
             'model' => $modell,
+            'temperature' => $temperature,
             'messages' => [
                 [
                     'role' => 'user',

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -13,12 +13,12 @@
             <trans-unit id="extconf.project_id" resname="extconf.project_id">
                 <source>The ID of the project at OpenAI</source>
             </trans-unit>
-			<trans-unit id="extconf.image_resizing" resname="extconf.image_resizing">
-				<source>Reduce image size to keep API costs low</source>
-			</trans-unit>
-			<trans-unit id="extconf.generate_alt_text_on_file_upload" resname="extconf.project_id">
-				<source>Generate alt-texts on file upload</source>
-			</trans-unit>
+            <trans-unit id="extconf.image_resizing" resname="extconf.image_resizing">
+                <source>Reduce image size to keep API costs low</source>
+            </trans-unit>
+            <trans-unit id="extconf.generate_alt_text_on_file_upload" resname="extconf.project_id">
+                <source>Generate alt-texts on file upload</source>
+            </trans-unit>
             <trans-unit id="extconf.api_base_uri" resname="extconf.project_id">
                 <source>Alternative API Endpoint. If not set openAI is used</source>
             </trans-unit>
@@ -26,7 +26,8 @@
                 <source>Selected model, default gpt-4o-mini</source>
             </trans-unit>
             <trans-unit id="extconf.temperature" resname="extconf.temperature">
-                <source>Temperature: Controls the randomness of the AI's output. Use lower values (0.1 - 0.3) for factual, precise, and consistent answers. Use higher values (0.7 - 1) for creative, diverse, and brainstorming tasks. </source>
+                <source>Temperature: Controls the randomness of the AI's output. Use lower values (0.1 - 0.3) for factual output and higher values (0.7 - 1.0) for creative tasks. Note: Leave blank if unsupported by the selected model (e.g., newer o1-models do not support temperature).</source>
+            </trans-unit>
             <trans-unit id="extconf.alt_text_prompt" resname="extconf.alt_text_prompt">
                 <source>Custom prompt for generating alternative text. Use \n for line breaks.</source>
             </trans-unit>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -25,6 +25,9 @@
             <trans-unit id="extconf.model" resname="extconf.project_id">
                 <source>Selected model, default gpt-4o-mini</source>
             </trans-unit>
+            <trans-unit id="extconf.temperature" resname="extconf.temperature">
+                <source>Temperature: Controls the randomness of the AI's output. Use lower values (0.1 - 0.3) for factual, precise, and consistent answers. Use higher values (0.7 - 1) for creative, diverse, and brainstorming tasks. </source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -20,6 +20,7 @@ imageResizing = 512
 generateAltTextOnFileUpload = 1
 
 # cat=OpenAI; type=string; label=LLL:EXT:ai_filemetadata/Resources/Private/Language/locallang_be.xlf:extconf.temperature
-temperature = 0.6
+temperature =
+
 # cat=OpenAI; type=text; label=LLL:EXT:ai_filemetadata/Resources/Private/Language/locallang_be.xlf:extconf.alt_text_prompt
 altTextPrompt = Create an alternative text for this image to be used on websites for visually impaired people who cannot see the image.\nFocus on the image's main content and ignore all elements in the image not relevant to understand its message.\nThe text should not exceed 50 words.

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -18,3 +18,6 @@ imageResizing = 512
 
 # cat=OpenAI; type=boolean; label=LLL:EXT:ai_filemetadata/Resources/Private/Language/locallang_be.xlf:extconf.generate_alt_text_on_file_upload
 generateAltTextOnFileUpload = 1
+
+# cat=OpenAI; type=string; label=LLL:EXT:ai_filemetadata/Resources/Private/Language/locallang_be.xlf:extconf.temperature
+temperature = 0.6


### PR DESCRIPTION
This allows users to fine-tune the randomness of the generated alt-texts. 
Adjusting the temperature helps in finding the sweet spot between factual accuracy (low temp) and natural phrasing (higher temp).
A low value prevents incorrect languages from appearing in German texts:
"Portrait eines middle أطلقanced Mannes mit locksigem, blondgräulich’envided Haar, das Rücken zeigt er eine Brille und trägt einาขcket und einen hellen Stoff darunter. Das Gesicht wirkt professionell und freundlich."