### PR TITLE
[BUGFIX] Lazy-initialize the site language mapping in FalAdapter

### DIFF
--- a/Classes/Services/FalAdapter.php
+++ b/Classes/Services/FalAdapter.php
@@ -117,6 +117,10 @@ class FalAdapter
 
     private function getLanguageMappingForFile(File $file): array
     {
+        if ($this->siteLanguageMapping === []) {
+            $this->siteLanguageMapping = $this->languageProvider->getFalLanguages();
+        }
+
         return $this->configurationService->getLanguageMappingForFile($file) ?? $this->siteLanguageMapping;
     }
 


### PR DESCRIPTION
Fixes #64

`FalAdapter::$siteLanguageMapping` is only populated inside `iterate()`. Every other caller of the public `localizeFile()` API sees an empty mapping: without `falLanguageMappings` configured, `getLanguageMappingForFile()` returns an empty array, the per-language loop runs zero times and the DataHandler receives an empty datamap — no alt text is written and no error is raised.

This initializes the mapping on first use inside `getLanguageMappingForFile()`, with the same `SiteLanguageProvider::getFalLanguages()` call `iterate()` already uses, so `localizeFile()` works standalone regardless of how it was reached.