### PR TITLE
[BUGFIX] Set a request timeout for the OpenAI client

### DIFF
--- a/Classes/Api/OpenAiClient.php
+++ b/Classes/Api/OpenAiClient.php
@@ -7,6 +7,8 @@ use Mfd\Ai\FileMetadata\Services\TokenUsageService;
 use OpenAI;
 use OpenAI\Client as OpenAiApiClient;
 use Psr\Log\LoggerInterface;
+use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException;
+use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExistException;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
 readonly class OpenAiClient
@@ -25,7 +27,14 @@ readonly class OpenAiClient
         if ($APIBaseUri === '') {
             $APIBaseUri = 'https://api.openai.com/v1/';
         }
+        // Vision requests on a 512px image measured between 5 and 20 seconds, so 60 leaves
+        // generous headroom while still bounding a stalled provider.
+        $httpClient = new \GuzzleHttp\Client([
+            'timeout' => $this->getTimeoutConfiguration('requestTimeout', 60),
+            'connect_timeout' => $this->getTimeoutConfiguration('connectTimeout', 10),
+        ]);
         $this->openAiClient = OpenAI::factory()
+            ->withHttpClient($httpClient)
             ->withBaseUri($APIBaseUri)
             ->withApiKey($apiKey)
             ->withOrganization($organizationId)
@@ -116,5 +125,22 @@ GPT;
 
 
         throw new \UnexpectedValueException('Did not find any choices in the response');
+    }
+
+    /**
+     * Values <= 0 fall back to the default on purpose: Guzzle treats 0 as "no timeout", which
+     * would silently reintroduce the very stall these timeouts exist to prevent. The catch
+     * covers updated installations whose extension configuration does not contain the new
+     * settings yet.
+     */
+    private function getTimeoutConfiguration(string $key, int $default): int
+    {
+        try {
+            $value = (int)$this->extensionConfiguration->get('ai_filemetadata', $key);
+        } catch (ExtensionConfigurationExtensionNotConfiguredException | ExtensionConfigurationPathDoesNotExistException) {
+            return $default;
+        }
+
+        return $value > 0 ? $value : $default;
     }
 }

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -22,6 +22,12 @@
             <trans-unit id="extconf.api_base_uri" resname="extconf.project_id">
                 <source>Alternative API Endpoint. If not set openAI is used</source>
             </trans-unit>
+            <trans-unit id="extconf.request_timeout" resname="extconf.request_timeout">
+                <source>Request timeout in seconds for OpenAI API calls. Empty or 0 falls back to the default of 60 seconds.</source>
+            </trans-unit>
+            <trans-unit id="extconf.connect_timeout" resname="extconf.connect_timeout">
+                <source>Connection timeout in seconds for OpenAI API calls. Empty or 0 falls back to the default of 10 seconds.</source>
+            </trans-unit>
             <trans-unit id="extconf.model" resname="extconf.project_id">
                 <source>Selected model, default gpt-4o-mini</source>
             </trans-unit>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -10,6 +10,12 @@ projectId =
 # cat=OpenAI; type=string; label=LLL:EXT:ai_filemetadata/Resources/Private/Language/locallang_be.xlf:extconf.api_base_uri
 apiBaseUri = https://api.openai.com/v1
 
+# cat=OpenAI; type=int+; label=LLL:EXT:ai_filemetadata/Resources/Private/Language/locallang_be.xlf:extconf.request_timeout
+requestTimeout = 60
+
+# cat=OpenAI; type=int+; label=LLL:EXT:ai_filemetadata/Resources/Private/Language/locallang_be.xlf:extconf.connect_timeout
+connectTimeout = 10
+
 # cat=OpenAI; type=string; label=LLL:EXT:ai_filemetadata/Resources/Private/Language/locallang_be.xlf:extconf.model
 model = gpt-4o-mini
 


### PR DESCRIPTION
Fixes #66

`OpenAI::factory()` resolves its HTTP client through `Psr18ClientDiscovery`, which finds Guzzle — and Guzzle defaults to `timeout => 0`, meaning no timeout at all. A provider that accepts the connection but never answers blocks the caller forever; on the scheduler path the task then never finishes and with `multiple=0` every following cron run is skipped, so generation stops silently.

This passes an explicit Guzzle client with a 60s request and 10s connect timeout to the factory. Vision requests on 512px images measured 5–20 seconds for us, so 60s leaves generous headroom while still bounding a stalled provider. TYPO3 ships Guzzle, so this adds no new dependency.

Both timeouts are configurable through the extension settings (`requestTimeout` / `connectTimeout`); empty or 0 falls back to the 60s/10s defaults.
