### PR TITLE
[BUGFIX] Dismiss the modal and notify the user when alt text generation fails

### DIFF
--- a/Resources/Private/Language/locallang_ai_filemetadata.xlf
+++ b/Resources/Private/Language/locallang_ai_filemetadata.xlf
@@ -8,16 +8,22 @@
                 <source>Automatically generate new alternative text</source>
             </trans-unit>
             <trans-unit id="notification.regenerate_alt_text.title" resname="notification.regenerate_alt_text.title">
-                <source>ai_filemetadata</source>
+                <source>Generating alternative text</source>
             </trans-unit>
             <trans-unit id="notification.regenerate_alt_text.message" resname="notification.regenerate_alt_text.message">
                 <source>Generating new alternative text...</source>
             </trans-unit>
             <trans-unit id="notification.alt_text_regenerated.title" resname="notification.alt_text_regenerated.title">
-                <source>ai_filemetadata</source>
+                <source>Alternative text generated</source>
             </trans-unit>
             <trans-unit id="notification.alt_text_regenerated.message" resname="notification.alt_text_regenerated.message">
                 <source>Alternative text successfully generated.</source>
+            </trans-unit>
+            <trans-unit id="notification.alt_text_generation_failed.title" resname="notification.alt_text_generation_failed.title">
+                <source>Alternative text generation failed</source>
+            </trans-unit>
+            <trans-unit id="notification.alt_text_generation_failed.message" resname="notification.alt_text_generation_failed.message">
+                <source>Please check the AI provider configuration (e.g. the API key) or try again later.</source>
             </trans-unit>
             <trans-unit id="sys_file_metadata.alttext_generation_date" resname="sys_file_metadata.alttext_generation_date">
                 <source>Automatic Alternative Text Generation Date</source>

--- a/Resources/Public/JavaScript/form-engine/element/ai-generated-alt-text-element.js
+++ b/Resources/Public/JavaScript/form-engine/element/ai-generated-alt-text-element.js
@@ -91,6 +91,12 @@ class AiGeneratedAltTextElement {
                     .dispatchEvent(new Event('change', {bubbles: true, cancelable: true}));
                 Notification.success(TYPO3.lang['notification.alt_text_regenerated.title'], TYPO3.lang['notification.alt_text_regenerated.message']);
                 Modal.dismiss();
+            }).catch((error) => {
+                if (error instanceof DOMException && error.name === 'AbortError') {
+                    return;
+                }
+                Modal.dismiss();
+                Notification.error(TYPO3.lang['notification.alt_text_generation_failed.title'], TYPO3.lang['notification.alt_text_generation_failed.message']);
             }).finally(() => {
                 element.request = null;
             });


### PR DESCRIPTION
Fixes #68

The promise chain in `recreateAltText()` only handled the success path. TYPO3's `AjaxRequest` rejects on non-2xx responses, so on any server-side failure (misconfigured API key, rate limit, provider outage) neither `Modal.dismiss()` nor a notification was reached — the "Generating new alternative text..." modal (static backdrop, no close button) stayed open forever and the editor got no hint what went wrong.

This adds a `.catch()` that dismisses the modal and shows an error notification pointing to the provider configuration, plus the two matching labels in `locallang_ai_filemetadata.xlf` (the file is already registered via `addInlineLanguageLabelFile()`, so the keys are available in `TYPO3.lang` automatically). Aborted requests (`AbortError`) intentionally stay silent.

While touching the labels, the `ai_filemetadata` notification titles are replaced with human-readable ones — **Generating alternative text** (modal), **Alternative text generated** (success) and **Alternative text generation failed** (error) — so editors see what is happening instead of an extension key.