### PR TITLE
Two bugs prevent reliable use of the `ai:generate-alt-texts` command

### DIFF
--- a/Classes/Command/GenerateAltTextsCommand.php
+++ b/Classes/Command/GenerateAltTextsCommand.php
@@ -67,7 +67,6 @@ class GenerateAltTextsCommand extends Command
             // Initialize both so CLI execution does not error out.
             $GLOBALS['BE_USER']->initializeUserSessionManager();
             $sessionProp = new \ReflectionProperty($GLOBALS['BE_USER'], 'userSession');
-            $sessionProp->setAccessible(true);
             if ($sessionProp->getValue($GLOBALS['BE_USER']) === null) {
                 $sessionProp->setValue(
                     $GLOBALS['BE_USER'],

--- a/Classes/Command/GenerateAltTextsCommand.php
+++ b/Classes/Command/GenerateAltTextsCommand.php
@@ -11,8 +11,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Authentication\CommandLineUserAuthentication;
 use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Session\UserSession;
 use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Resource\Search\FileSearchDemand;
 use TYPO3\CMS\Core\Resource\StorageRepository;
@@ -53,11 +56,25 @@ class GenerateAltTextsCommand extends Command
     {
         ProgressBar::setFormatDefinition('with_message', ' %current%/%max% [%bar%] %message%');
 
-        if (version_compare(VersionNumberUtility::getCurrentTypo3Version(), '13.0', '>=')) {
-            Bootstrap::initializeBackendUser(
-                \TYPO3\CMS\Core\Authentication\CommandLineUserAuthentication::class, null);
+        if (Environment::isCli()) {
+            if (version_compare(VersionNumberUtility::getCurrentTypo3Version(), '13.0', '>=')) {
+                Bootstrap::initializeBackendUser(CommandLineUserAuthentication::class, null);
+            }
+            Bootstrap::initializeBackendAuthentication();
+            // CommandLineUserAuthentication::start() skips session initialization,
+            // leaving userSession/userSessionManager uninitialized. DataHandler writes
+            // flash messages via setAndSaveSessionData() which would crash on null.
+            // Initialize both so CLI execution does not error out.
+            $GLOBALS['BE_USER']->initializeUserSessionManager();
+            $sessionProp = new \ReflectionProperty($GLOBALS['BE_USER'], 'userSession');
+            $sessionProp->setAccessible(true);
+            if ($sessionProp->getValue($GLOBALS['BE_USER']) === null) {
+                $sessionProp->setValue(
+                    $GLOBALS['BE_USER'],
+                    UserSession::createNonFixated('cli-' . bin2hex(random_bytes(8)))
+                );
+            }
         }
-        Bootstrap::initializeBackendAuthentication();
 
 
         $doOverwriteMetadata = $input->getOption('overwrite');

--- a/Classes/Services/FalAdapter.php
+++ b/Classes/Services/FalAdapter.php
@@ -86,11 +86,11 @@ class FalAdapter
                 $this->logger->debug('Skipped due to exclude pattern');
                 continue;
             }
-            if (intval($meta['alttext_generation_date']) > 0) {
+            if (!$overwriteMetadata && intval($meta['alttext_generation_date']) > 0) {
                 $this->logger->debug('Skipped due already generated alt text');
                 continue;
             }
-            if ((isset($meta['alternative']) && trim($meta['alternative']) !== '') && (!$overwriteMetadata)) {
+            if (!$overwriteMetadata && (isset($meta['alternative']) && trim($meta['alternative']) !== '')) {
                 $this->logger->debug('Skipped due already existing (manual?) alt text');
                 continue;
             }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "name": "mfd/ai-filemetadata",
   "type": "typo3-cms-extension",
   "description": "Automatically generates FAL metadata for files by means of public LLMs",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "keywords": [
     "TYPO3 CMS",
     "Extension",


### PR DESCRIPTION
1. **Scheduler incompatibility:** Running the command via the TYPO3 Scheduler
   (non-CLI context) throws `Creating a CLI-based user object on non-CLI level
   is not allowed`, because `Bootstrap::initializeBackendUser(CommandLineUserAuthentication::class)`
   is called unconditionally — even when `BE_USER` is already set by the Scheduler.
   Additionally, `CommandLineUserAuthentication::start()` intentionally skips
   session initialization, leaving `userSession` and `userSessionManager` unset.
   `DataHandler` then crashes with `Call to a member function set() on null` when
   writing flash messages via `setAndSaveSessionData()`.

2. **`--overwrite` flag ineffective:** Files that already have an
   `alttext_generation_date` set are always skipped, regardless of `--overwrite`.
   Only the `alternative` text field respected the flag — making it impossible to
   regenerate alt texts for previously processed files.

## Solution

**`GenerateAltTextsCommand`:** Backend user initialization is now guarded by
`Environment::isCli()`, so it is skipped when the command runs via Scheduler.
For CLI execution, `initializeUserSessionManager()` is called explicitly and a
transient `UserSession` is created so `DataHandler` can write flash messages
without crashing.

**`FalAdapter`:** Both skip conditions (`alttext_generation_date` and `alternative`)
now consistently check the `$overwriteMetadata` flag before skipping a file.