### PR TITLE
[TASK] Implemnent Create flag to separate ai generated content from n…

### DIFF
--- a/Classes/Backend/Controller/AiGeneratedAltTextAjaxController.php
+++ b/Classes/Backend/Controller/AiGeneratedAltTextAjaxController.php
@@ -3,6 +3,7 @@
 namespace Mfd\Ai\FileMetadata\Backend\Controller;
 
 use Mfd\Ai\FileMetadata\Api\OpenAiClient;
+use Mfd\Ai\FileMetadata\Cache\AltTextSuggestionCache;
 use Mfd\Ai\FileMetadata\Domain\Model\FileMetadata;
 use Mfd\Ai\FileMetadata\Domain\Repository\FileMetadataRepository;
 use Mfd\Ai\FileMetadata\Services\ConfigurationService;
@@ -49,6 +50,10 @@ trait AiGeneratedAltTextAjaxControllerTrait {
                 'backend',
                 $file->getUid(),
             );
+
+            // Remembered so the DataHandler hook can recognize this exact text being saved
+            // unmodified as still AI-generated (see ResetAltTextGenerationDateHook).
+            $this->suggestionCache->remember($recordId, (int)($GLOBALS['BE_USER']->user['uid'] ?? 0), $altText);
 
             return new JsonResponse([
                 'text' => $altText,
@@ -129,6 +134,7 @@ if (GeneralUtility::makeInstance(Typo3Version::class)->getMajorVersion() >= 14) 
             private ConfigurationService $configurationService,
             private SiteLanguageProvider $languageProvider,
             private FalAdapter $falAdapter,
+            private AltTextSuggestionCache $suggestionCache,
         ) {
         }
     }
@@ -144,6 +150,7 @@ if (GeneralUtility::makeInstance(Typo3Version::class)->getMajorVersion() >= 14) 
             private readonly ConfigurationService $configurationService,
             private readonly SiteLanguageProvider $languageProvider,
             private readonly FalAdapter $falAdapter,
+            private readonly AltTextSuggestionCache $suggestionCache,
         ) {
         }
     }

--- a/Classes/Cache/AltTextSuggestionCache.php
+++ b/Classes/Cache/AltTextSuggestionCache.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mfd\Ai\FileMetadata\Cache;
+
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Cache\Exception\NoSuchCacheException;
+use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
+
+/**
+ * Stores the exact text an AI "recreate alt text" suggestion produced for a
+ * sys_file_metadata record, so the DataHandler hook check:
+ *  - the suggestion being saved unmodified (still AI-generated)
+ *  - the suggestion being edited by hand before saving (no longer AI-generated)
+ */
+class AltTextSuggestionCache
+{
+    public const CACHE_IDENTIFIER = 'ai_filemetadata_alttext_suggestions';
+
+    public function __construct(private readonly CacheManager $cacheManager)
+    {
+    }
+
+    public function remember(int $metadataUid, int $backendUserUid, string $suggestedText): void
+    {
+        $this->getCache()->set($this->cacheEntryIdentifier($metadataUid, $backendUserUid), $suggestedText);
+    }
+
+    public function get(int $metadataUid, int $backendUserUid): ?string
+    {
+        $value = $this->getCache()->get($this->cacheEntryIdentifier($metadataUid, $backendUserUid));
+
+        return $value === false ? null : $value;
+    }
+
+    public function forget(int $metadataUid, int $backendUserUid): void
+    {
+        $this->getCache()->remove($this->cacheEntryIdentifier($metadataUid, $backendUserUid));
+    }
+
+    private function cacheEntryIdentifier(int $metadataUid, int $backendUserUid): string
+    {
+        return 'suggestion_' . $metadataUid . '_' . $backendUserUid;
+    }
+
+    private function getCache(): FrontendInterface
+    {
+        try {
+            return $this->cacheManager->getCache(self::CACHE_IDENTIFIER);
+        } catch (NoSuchCacheException) {
+            return $this->cacheManager->getCache('runtime');
+        }
+    }
+}

--- a/Classes/Hooks/ResetAltTextGenerationDateHook.php
+++ b/Classes/Hooks/ResetAltTextGenerationDateHook.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mfd\Ai\FileMetadata\Hooks;
+
+use Mfd\Ai\FileMetadata\Cache\AltTextSuggestionCache;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Http\ApplicationType;
+use TYPO3\CMS\Core\Utility\MathUtility;
+
+/**
+ * Keeps sys_file_metadata.alttext_generation_date honest for every write that goes through the DataHandler:
+ *
+ * - FalAdapter::localizeFile() always sets "alternative" and "alttext_generation_date" together in the same
+ *   field array - that write is left untouched, it's the AI generation itself.
+ * - The upload autogeneration (EnrichFileMetadataAfterCreation) bypasses the DataHandler entirely via a direct
+ *   query, so it never reaches this hook either.
+ * - Any other write that changes "alternative" without also carrying "alttext_generation_date" is either a
+ *   manual edit in the backend form, or the AI-suggested text from the "recreate" button that was edited
+ *   before saving. Both cases must clear the generation date - unless the saved text is byte-for-byte the
+ *   suggestion that was just generated, in which case it still counts as AI-generated.
+ */
+class ResetAltTextGenerationDateHook
+{
+    private const TABLE = 'sys_file_metadata';
+
+    public function __construct(private readonly AltTextSuggestionCache $suggestionCache)
+    {
+    }
+
+    public function processDatamap_preProcessFieldArray(array &$incomingFieldArray, string $table, string $id, DataHandler $parentObject): void
+    {
+        // CLI writes (e.g. GenerateAltTextsCommand via FalAdapter) are trusted AI/import contexts -
+        // let them through untouched instead of running the manual-edit detection below.
+        if (Environment::isCli()) {
+            return;
+        }
+
+        // Frontend-triggered uploads/edits (e.g. via a form) are intentionally out of scope here -
+        // anyone needing this reset behavior for FE writes has to implement it themselves.
+        $request = $GLOBALS['TYPO3_REQUEST'] ?? null;
+        if ($request instanceof ServerRequestInterface && ApplicationType::fromRequest($request)->isFrontend()) {
+            return;
+        }
+
+        if ($table !== self::TABLE) {
+            return;
+        }
+
+        if (!array_key_exists('alternative', $incomingFieldArray)) {
+            return;
+        }
+
+        // Already an all-in-one AI write (FalAdapter): don't interfere.
+        if (array_key_exists('alttext_generation_date', $incomingFieldArray)) {
+            return;
+        }
+
+        // New records can't have an AI-generated date to invalidate yet.
+        if (!MathUtility::canBeInterpretedAsInteger($id)) {
+            return;
+        }
+        $id = intval($id);
+
+        $currentRecord = BackendUtility::getRecord(self::TABLE, $id, 'alternative,alttext_generation_date');
+        if ($currentRecord === null) {
+            return;
+        }
+
+        $incomingAlternative = trim((string)$incomingFieldArray['alternative']);
+
+        // FormEngine resubmits unchanged fields on every save - only react if the text actually changed.
+        if ($incomingAlternative === trim((string)$currentRecord['alternative'])) {
+            return;
+        }
+
+        $backendUserUid = (int)($parentObject->BE_USER->user['uid'] ?? 0);
+        $suggestion = $this->suggestionCache->get($id, $backendUserUid);
+        $this->suggestionCache->forget($id, $backendUserUid);
+
+        if ($suggestion !== null && $incomingAlternative === trim($suggestion)) {
+            // The AI suggestion was saved unmodified.
+            $incomingFieldArray['alttext_generation_date'] = time();
+            return;
+        }
+
+        // Typed by hand, or the AI suggestion was edited before saving.
+        if ((int)$currentRecord['alttext_generation_date'] !== 0) {
+            $incomingFieldArray['alttext_generation_date'] = 0;
+        }
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,7 +3,7 @@
 use Mfd\Ai\FileMetadata\Cache\AltTextSuggestionCache;
 use Mfd\Ai\FileMetadata\Form\Element\AiGeneratedAltTextElement;
 use Mfd\Ai\FileMetadata\Hooks\ResetAltTextGenerationDateHook;
-use TYPO3\CMS\Core\Cache\Backend\SimpleFileBackend;
+use TYPO3\CMS\Core\Cache\Backend\Typo3DatabaseBackend;
 use TYPO3\CMS\Core\Cache\Frontend\VariableFrontend;
 
 call_user_func(static function () {
@@ -13,9 +13,11 @@ call_user_func(static function () {
         'class' => AiGeneratedAltTextElement::class,
     ];
 
+    // Typo3DatabaseBackend, not SimpleFileBackend: suggestion and save can hit different app
+    // servers behind a load balancer, so the cache must be shared via the database, not local disk.
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][AltTextSuggestionCache::CACHE_IDENTIFIER] ??= [
         'frontend' => VariableFrontend::class,
-        'backend' => SimpleFileBackend::class,
+        'backend' => Typo3DatabaseBackend::class,
         'options' => [
             'defaultLifetime' => 3600,
         ],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,6 +1,10 @@
 <?php
 
+use Mfd\Ai\FileMetadata\Cache\AltTextSuggestionCache;
 use Mfd\Ai\FileMetadata\Form\Element\AiGeneratedAltTextElement;
+use Mfd\Ai\FileMetadata\Hooks\ResetAltTextGenerationDateHook;
+use TYPO3\CMS\Core\Cache\Backend\SimpleFileBackend;
+use TYPO3\CMS\Core\Cache\Frontend\VariableFrontend;
 
 call_user_func(static function () {
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1722516398] = [
@@ -8,5 +12,18 @@ call_user_func(static function () {
         'priority' => 40,
         'class' => AiGeneratedAltTextElement::class,
     ];
+
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][AltTextSuggestionCache::CACHE_IDENTIFIER] ??= [
+        'frontend' => VariableFrontend::class,
+        'backend' => SimpleFileBackend::class,
+        'options' => [
+            'defaultLifetime' => 3600,
+        ],
+    ];
+
+    // Resets sys_file_metadata.alttext_generation_date whenever "alternative" is changed by hand
+    // (see ResetAltTextGenerationDateHook for the full reasoning).
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][ResetAltTextGenerationDateHook::class]
+        = ResetAltTextGenerationDateHook::class;
 });
 


### PR DESCRIPTION
…on ai generated content. Fixes #74

This PR ads:

- A cache which stores the generated alt-text via Ajax request. 
- A hook to check:
- -  if the Alt-Text is changed -> Resets the timestamp for the generated alt-text
- - if the alt-text is different from the cache -> Resets the timestamp for the generated alt-text


